### PR TITLE
rename the session key with new app name

### DIFF
--- a/lib/generators/rename_to/rename_to_generator.rb
+++ b/lib/generators/rename_to/rename_to_generator.rb
@@ -39,6 +39,10 @@ class RenameToGenerator < Rails::Generators::Base
       gsub_file 'config/initializers/session_store.rb', /(#{Regexp.escape(old_name)})(::Application.config.session_store)/mi do |match|
         "#{new_name_capitalized}::Application.config.session_store"
       end
+
+      gsub_file 'config/initializers/session_store.rb', /#{Regexp.escape(old_name.underscore)}/ do |match|
+        "#{new_name_capitalized.underscore}"
+      end
       
       gsub_file 'Rakefile', /(#{Regexp.escape(old_name.capitalize)})(::Application.load_tasks)/mi do |match|
         "#{new_name_capitalized}::Application.load_tasks"


### PR DESCRIPTION
This PR fixes issue #3. In session_store.rb, the key will be renamed along with the rest of the application.
